### PR TITLE
[WIP] Adding a production dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# pull official base image
+FROM node:12.18.4-alpine
+
+# set working directory
+WORKDIR /app
+
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH /app/node_modules/.bin:$PATH
+
+# install app dependencies
+COPY package.json ./
+COPY yarn.lock ./
+COPY prettier.config.js ./
+COPY tsconfig.json ./
+COPY tslint.json ./
+COPY public ./public
+COPY src ./src
+
+# build the app
+RUN yarn install --silent
+RUN yarn build
+
+RUN rm -rf src
+RUN rm -rf public
+RUN rm -rf node_modules
+RUN rm package.json yarn.lock prettier.config.js tsconfig.json tslint.json
+
+# start app
+CMD ["npm", "start"]


### PR DESCRIPTION
This is not yet ready for merge, but this will successfully build a container with only `/app/build`.

Next steps are to move the build folder itself into a thin container for running inside of nginx or something similar for serving the static assets.